### PR TITLE
Implemented CRUD_EVENT_NO_CHANGED_FIELDS_SKIP

### DIFF
--- a/easyaudit/signals/model_signals.py
+++ b/easyaudit/signals/model_signals.py
@@ -18,7 +18,7 @@ from easyaudit.middleware.easyaudit import get_current_request, \
 from easyaudit.models import CRUDEvent
 from easyaudit.settings import REGISTERED_CLASSES, UNREGISTERED_CLASSES, \
     WATCH_MODEL_EVENTS, CRUD_DIFFERENCE_CALLBACKS, LOGGING_BACKEND, \
-    DATABASE_ALIAS
+    DATABASE_ALIAS, CRUD_EVENT_NO_CHANGED_FIELDS_SKIP
 from easyaudit.utils import get_m2m_field_name, model_delta
 
 logger = logging.getLogger(__name__)
@@ -73,6 +73,9 @@ def pre_save(sender, instance, raw, using, update_fields, **kwargs):
     try:
         if not should_audit(instance):
             return False
+        
+        if CRUD_EVENT_NO_CHANGED_FIELDS_SKIP:
+            return
 
         with transaction.atomic(using=using):
             try:


### PR DESCRIPTION
I experienced issues with replicas when pre_save is used. To avoid this issues, I'd like to silence pre_saves.

I saw we have the flag CRUD_EVENT_NO_CHANGED_FIELDS_SKIP already in documentation but not implemented it. Please let me know if this fix implements CRUD_EVENT_NO_CHANGED_FIELDS_SKIP as it was intended.

Thanks